### PR TITLE
[#92418938] Avoids mu textures to be overridden by unpacking

### DIFF
--- a/import_mu.py
+++ b/import_mu.py
@@ -277,7 +277,9 @@ def load_mbm(mbmpath):
 
 def load_image(name, path):
     if name[-4:].lower() in [".png", ".tga"]:
-        bpy.data.images.load(os.path.join(path, name))
+        img = bpy.data.images.load(os.path.join(path, name))
+        img.pack(True)
+        img.filepath = img.filepath[:-4] + os.path.split(path)[-1] + '.png'
     elif name[-4:].lower() == ".mbm":
         w,h, pixels = load_mbm(os.path.join(path, name))
         img = bpy.data.images.new(name, w, h)


### PR DESCRIPTION
In osgexport, packed textures are unpacked into files whose names are the basename of the
blender image's filepath. Since mu textures have the same name for each parts (model000.png etc),
we must rename the basename of the blender image's path to avoid the overridding at the unpacking step. This issues concerns only PNG or TGA textures since the loading of a MBM generates a new blender image with empty path.